### PR TITLE
optee_client: Changes required so that client RPMS may be built

### DIFF
--- a/libteeacl/teeacl.pc.in
+++ b/libteeacl/teeacl.pc.in
@@ -7,6 +7,6 @@ Name: @PROJECT_NAME@
 Description: Access Control List utilities for teec library
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: uuid >= 2.34
+Requires: uuid >= 2.32
 Cflags: -I"${includedir}"
 Libs: -L"${libdir}" -lteeacl

--- a/optee-client.spec
+++ b/optee-client.spec
@@ -16,12 +16,12 @@
 #
 
 
-%define libname libteec1
+%define libname libteec2
 %define libname2 libckteec0
 %define libname3 libseteec0
 %define libname4 libteeacl0
 Name:           optee-client
-Version:        3.22.1
+Version:        3.22.2
 Release:        0
 Summary:        A Trusted Execution Environment client
 License:        BSD-2-Clause
@@ -119,6 +119,8 @@ systemctl daemon-reload >/dev/null 2>&1 || :
 %{_sbindir}/tee-supplicant
 %{_sysconfdir}/modprobe.d/tpm_ftpm_tee.conf
 %{_unitdir}/tee-supplicant.service
+%{_libdir}/pkgconfig/teeacl.pc
+%{_libdir}/pkgconfig/teec.pc
 
 %files devel
 %{_includedir}/*.h


### PR DESCRIPTION
(A) After making these changes I natively built the RPMs for OCI

(1) Installed these packages

yum install rpmdevtools   
yum install rpm-build
yum install cmake
yum install libuuid-devel.aarch64

Note that I had to make sure that there was a uuid package installed >= 2.32 and if not install it.
For OCI for instance I had to install libuuid-devel.aarch64.

(2)  rpmdev-setuptree
Update this repot with the 2 files above
mv optee_client  optee_client-3.22.2
tar -czvf optee_client-3.22.2.tar.gz optee_client-3.22.2
cp optee_client-3.22.2.tar.gz rpmbuild/SOURCES
cp optee_client/optee-client.spec rpmbuild/SPECS
cd rpmbuild/SPECS
rpm -ba optee-client.spec
We now have the RPMs built
libteec2-3.22.2.aarch64.rpm
optee-client-3.22.2-0.aarch64.rpm
Install the just built RPMs

[root@bu-lab106-oob aarch64]# rpm -iv libteec2-3.22.2-0.aarch64.rpm
Verifying packages...
Preparing packages...
libteec2-3.22.2-0.aarch64

[root@bu-lab106-oob aarch64]#  rpm -iv optee-client-3.22.2-0.aarch64.rpm
Verifying packages...
Preparing packages...
optee-client-3.22.2-0.aarch64

Verify the NEW tee-supplicant was updated properly:

[root@bu-lab106-oob aarch64]# ldd /usr/sbin/tee-supplicant
        linux-vdso.so.1 (0x0000ffffb4571000)
        libteec.so.2 => /lib64/libteec.so.2 (0x0000ffffb44e0000)
        libdl.so.2 => /lib64/libdl.so.2 (0x0000ffffb44b0000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x0000ffffb4470000)
        libc.so.6 => /lib64/libc.so.6 (0x0000ffffb42f0000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffffb4533000)

The original (old tee-supplicant)

[root@bu-lab106-oob aarch64]# ldd /usr/sbin/tee-supplicant
       linux-vdso.so.1 (0x0000ffffa72f0000)
        libteec.so.1 => /lib64/libteec.so.1 (0x0000ffffa7260000)
        libdl.so.2 => /lib64/libdl.so.2 (0x0000ffffa7230000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x0000ffffa71f0000)
        libc.so.6 => /lib64/libc.so.6 (0x0000ffffa7070000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffffa7300000)
        
(B)  Also had to verify Debian works for Ubuntu:
 
(1) Installed these packages:

apt install devscripts
apt install docbook-xsl
apt install xsltproc
apt install equivs
apt install uuid-dev

cp -r  optee_client  optee_client-3.22.2.orig
tar -czvf optee_client_3.22.1.orig.tar.gz optee_client_3.22.2.orig

cd optee_client-3.22.2.orig
debuild -us -uc

    