### PR TITLE
optee_client 4.2.3 packed as 3.22.1 on UBuntu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+optee-client (4.2.4-1) unstable; urgency=low
+
+  *  Update change log to reflect our current optee-client patch version
+
+ -- Jim Hurley <jahurley@nvidia.com>  Mon, 10 Mar 2025 15:51:22 +0000
+
 optee-client (3.22.1-1) unstable; urgency=low
 
   * Fix build for upstream version 3.22

--- a/optee-client.spec
+++ b/optee-client.spec
@@ -21,7 +21,7 @@
 %define libname3 libseteec0
 %define libname4 libteeacl0
 Name:           optee-client
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        A Trusted Execution Environment client
 License:        BSD-2-Clause


### PR DESCRIPTION
The Debian changelog needs to be updated to reflect the tag we are using to build the branch.
Was showing the old branch, need to show the latest.

Note: Once this commit goes in this tag will need to be
updated to reflect this change.

RM #4336836